### PR TITLE
[41기 서지연] Feature/inputComponents : input & label 공용 컴포넌트 구현 완료

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Input = ({ id, type, disabled = false, required = false }) => {
+  return (
+    <InputStyle id={id} type={type} disabled={disabled} required={required} />
+  );
+};
+
+const InputStyle = styled.input`
+  width: 340px;
+  height: 50px;
+  padding-left: 20px;
+  font-size: ${props => props.theme.fontSize.l};
+  color: ${props => props.theme.colors.primary};
+  font-weight: ${props => props.theme.fontWeight.bold};
+  border: 2px solid ${props => props.theme.colors.primary};
+  border-radius: 5px;
+
+  &:disabled {
+    outline: none;
+    background-color: ${props => props.theme.colors.control};
+    color: ${props => props.theme.colors.primary};
+  }
+
+  &:focus {
+    outline: none;
+    border: 3px solid ${props => props.theme.colors.primary};
+  }
+
+  &:invalid {
+    outline: none;
+    border: 3px solid ${props => props.theme.colors.warning};
+  }
+`;
+
+export default Input;

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Label = ({ htmlFor, children }) => {
+  return <LabelStyle htmlFor={htmlFor}>{children}</LabelStyle>;
+};
+
+const LabelStyle = styled.label`
+  font-size: ${props => props.theme.fontSize.l};
+  color: ${props => props.theme.colors.primary};
+  font-weight: ${props => props.theme.fontWeight.bold};
+`;
+
+export default Label;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- input & label  공용 컴포넌트 구현

<br />

## :: 구현 사항 설명 
- input 기본값 설정 & disabled, focus, invaild 상황별로 style 설정
- component에 props로 id, type, disabled, required 받아 전달해줌
- label component에 props로 htemlFor, children props를 받음.

<br />

## :: 성장 포인트 
- props로 받아야하는 정보를 넘겨주는 부분을 받을 수 있고 안에 내용은 children을 통해 받을 수 있다.
<br />

## :: 기타 질문 및 특이 사항
- label에서 사용하는 for은 jsx에서 htmlFor로 사용!