### PR TITLE
[41기 서지연] Add: selected 페이지 레이아웃 구현완료 & Modify: Button 컴포넌트 수정

### DIFF
--- a/public/data/seats.json
+++ b/public/data/seats.json
@@ -1,0 +1,37 @@
+[
+  [
+    { "name": "a1", "isBooked": 1 },
+    { "name": "a2", "isBooked": 0 },
+    { "name": "a3", "isBooked": 0 },
+    { "name": "a4", "isBooked": 1 },
+    { "name": "a5", "isBooked": 1 }
+  ],
+  [
+    { "name": "b1", "isBooked": 1 },
+    { "name": "b2", "isBooked": 1 },
+    { "name": "b3", "isBooked": 1 },
+    { "name": "b4", "isBooked": 1 },
+    { "name": "b5", "isBooked": 1 }
+  ],
+  [
+    { "name": "c1", "isBooked": 1 },
+    { "name": "c2", "isBooked": 1 },
+    { "name": "c3", "isBooked": 1 },
+    { "name": "c4", "isBooked": 1 },
+    { "name": "c5", "isBooked": 1 }
+  ],
+  [
+    { "name": "d1", "isBooked": 1 },
+    { "name": "d2", "isBooked": 1 },
+    { "name": "d3", "isBooked": 1 },
+    { "name": "d4", "isBooked": 1 },
+    { "name": "d5", "isBooked": 1 }
+  ],
+  [
+    { "name": "e1", "isBooked": 1 },
+    { "name": "e2", "isBooked": 1 },
+    { "name": "e3", "isBooked": 1 },
+    { "name": "e4", "isBooked": 1 },
+    { "name": "e5", "isBooked": 1 }
+  ]
+]

--- a/src/Router.js
+++ b/src/Router.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Nav from './components/Nav/Nav';
 import Main from './pages/Main/Main';
+import Selected from './pages/Selected/Selected';
 import Footer from './components/Footer/Footer';
 
 const Router = () => {
@@ -10,6 +11,7 @@ const Router = () => {
       <Nav />
       <Routes>
         <Route path="/" element={<Main />} />
+        <Route path="/selected" element={<Selected />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/pages/Selected/Selected.js
+++ b/src/pages/Selected/Selected.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import SelectForm from './components/SelectForm';
+import UserInfo from './components/UserInfo';
+import SelectSeat from './components/SelectSeat';
+import * as S from './Selected.styles';
+
+export default function Selected() {
+  return (
+    <S.SelectedContainer className="inner">
+      <SelectForm w="45%" title="예약하기">
+        <UserInfo />
+      </SelectForm>
+      <SelectForm w="45%" title="좌석 선택">
+        <SelectSeat />
+      </SelectForm>
+    </S.SelectedContainer>
+  );
+}

--- a/src/pages/Selected/Selected.styles.js
+++ b/src/pages/Selected/Selected.styles.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const SelectedContainer = styled.div`
+  ${props => props.theme.variables.flex('', 'space-evenly', '')}
+  height: 90vh;
+`;

--- a/src/pages/Selected/components/SelectForm.jsx
+++ b/src/pages/Selected/components/SelectForm.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Button from '../../../components/Button';
+import * as S from './SelectForm.styles';
+
+export default function SelectForm({ w, title, children }) {
+  return (
+    <S.SelectFormContainer w={w}>
+      <S.Title>{title}</S.Title>
+      <S.SelectContents>{children}</S.SelectContents>
+      <Button size="large" color="primary">
+        {title}
+      </Button>
+    </S.SelectFormContainer>
+  );
+}

--- a/src/pages/Selected/components/SelectForm.styles.js
+++ b/src/pages/Selected/components/SelectForm.styles.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const SelectFormContainer = styled.div`
+  ${props => props.theme.variables.flex('column', 'space-evenly', 'center')};
+  width: ${props => props.w};
+  height: 100%;
+  background-color: ${props => props.theme.colors.control};
+`;
+
+export const Title = styled.p`
+  padding-bottom: 10px;
+  border-bottom: 3px solid ${props => props.theme.colors.primary};
+  color: ${props => props.theme.colors.primary};
+  font-size: ${props => props.theme.fontSize.title2};
+  font-weight: ${props => props.theme.fontWeight.bold};
+`;
+
+export const SelectContents = styled.form`
+  ${props => props.theme.variables.flex('column', 'center', 'center')}
+  gap: 10px;
+`;

--- a/src/pages/Selected/components/SelectSeat.jsx
+++ b/src/pages/Selected/components/SelectSeat.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { MdOutlineChairAlt } from 'react-icons/md';
+import * as S from './SelectSeat.styles';
+
+export default function SelectSeat() {
+  const [seats, setSeats] = useState([]);
+
+  useEffect(() => {
+    fetch('./data/seats.json')
+      .then(res => res.json())
+      .then(data => {
+        setSeats(data);
+      });
+  }, [seats]);
+
+  return (
+    <S.SelectSeatContainer>
+      <S.ChalkBoard>칠판</S.ChalkBoard>
+      <S.Windows>
+        <S.SeatInfo>창문</S.SeatInfo>
+        <S.SeatInfo>창문</S.SeatInfo>
+      </S.Windows>
+      <S.Door>문</S.Door>
+      <S.Seats>
+        {seats.map(seat =>
+          seat.map(({ name, isBooked }) => (
+            <S.Seat key={name} isbooked={isBooked}>
+              <MdOutlineChairAlt size="32px" />
+            </S.Seat>
+          ))
+        )}
+      </S.Seats>
+    </S.SelectSeatContainer>
+  );
+}

--- a/src/pages/Selected/components/SelectSeat.styles.js
+++ b/src/pages/Selected/components/SelectSeat.styles.js
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+
+export const SelectSeatContainer = styled.div`
+  display: grid;
+  grid-template-columns: 10% 82% 8%;
+  grid-template-rows: 10% 90%;
+  grid-template-areas:
+    'a board b'
+    'windows seats door';
+  ${props => props.theme.variables.wh('100%', '55vh')}
+  background-color: white;
+  border-radius: 5px;
+`;
+
+export const SeatInfo = styled.div`
+  ${props => props.theme.variables.flex('', 'center', 'center')}
+  ${props => props.theme.variables.wh('70%', '20%')};
+  padding: 0 5px;
+  border: 1px solid ${props => props.theme.colors.primary};
+  border-radius: 5px;
+  color: ${props => props.theme.colors.primary};
+  font-weight: ${props => props.theme.fontWeight.bold};
+  font-size: ${props => props.theme.fontSize.m};
+`;
+
+export const ChalkBoard = styled(SeatInfo)`
+  grid-area: board;
+  ${props => props.theme.variables.wh('40%', '60%')}
+  margin-top: 10px;
+  margin-left: 30%;
+`;
+
+export const Windows = styled.div`
+  ${props => props.theme.variables.flex('column', 'space-evenly', 'center')}
+  grid-area: windows;
+  padding-left: 1px;
+`;
+
+export const Door = styled(SeatInfo)`
+  grid-area: door;
+  margin-top: 80%;
+`;
+
+export const Seats = styled.div`
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  grid-template-rows: repeat(5, 1fr);
+  grid-gap: 15px;
+  grid-area: seats;
+  margin: 30px;
+`;
+
+export const Seat = styled.div`
+  color: ${props =>
+    props.isbooked ? props.theme.colors.primary : props.theme.colors.basic};
+`;

--- a/src/pages/Selected/components/UserInfo.jsx
+++ b/src/pages/Selected/components/UserInfo.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import * as S from './UserInfo.styles';
+
+export default function UserInfo() {
+  return (
+    <>
+      {INPUT_LIST.map(({ id, title, placeholder }) => (
+        <>
+          <S.UserInfoContainer key={id}>
+            <S.Labels htmlFor={id}>{title}</S.Labels>
+            <S.Inputs
+              id={id}
+              disabled={id.includes('exam')}
+              placeholder={placeholder}
+            />
+            {id.includes('phone') && (
+              <S.SmallBtn color="primary">
+                {id === 'phone' ? '인증' : '확인'}
+              </S.SmallBtn>
+            )}
+          </S.UserInfoContainer>
+          {id === 'phone' && (
+            <S.WarnningMsg>9자 이상 가능합니다.(숫자만)</S.WarnningMsg>
+          )}
+          {id === 'email' && (
+            <S.WarnningMsg>이메일 주소를 다시 확인해주세요.</S.WarnningMsg>
+          )}
+        </>
+      ))}
+    </>
+  );
+}
+
+const INPUT_LIST = [
+  { id: 'examName', title: '시험' },
+  { id: 'examDate', title: '시험 일정' },
+  { id: 'examPlace', title: '고사장' },
+  { id: 'examSeat', title: '좌석' },
+  { id: 'name', title: '이름' },
+  { id: 'phone', title: '휴대폰' },
+  { id: 'phoneCheck', title: '인증번호', placeholder: '숫자(6자리)' },
+  { id: 'email', title: '이메일' },
+];

--- a/src/pages/Selected/components/UserInfo.styles.js
+++ b/src/pages/Selected/components/UserInfo.styles.js
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import { StyledButton } from '../../../components/Button';
+
+export const UserInfoContainer = styled.div`
+  ${props => props.theme.variables.flex('', 'center', 'center')}
+  position: relative;
+  width: 100%;
+  border: 2px solid ${props => props.theme.colors.primary};
+  border-radius: 3px;
+`;
+
+export const Labels = styled.label`
+  flex: 3;
+  padding: 10px 15px;
+  color: ${props => props.theme.colors.primary};
+  font-size: ${props => props.theme.fontSize.title3};
+  font-weight: ${props => props.theme.fontWeight.bold};
+`;
+
+export const Inputs = styled.input`
+  flex: 7;
+  height: 100%;
+  padding: 10px 20px;
+  border: none;
+  color: ${props => props.theme.colors.primary};
+  font-size: ${props => props.theme.fontSize.title3};
+
+  &:disabled {
+    background-color: ${props => props.theme.colors.control};
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    font-size: ${props => props.theme.fontSize.m};
+  }
+`;
+
+export const WarnningMsg = styled.p`
+  color: ${props => props.theme.colors.warning};
+  font-size: ${props => props.theme.fontSize.s};
+`;
+
+export const SmallBtn = styled(StyledButton)`
+  ${props => props.theme.variables.wh('50px', '40px')}
+  position: absolute;
+  right: 0px;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [X] 컨벤션 수정

<br />

## :: 구현 목표 
1. selected 페이지 레이아웃 구현
2. Button 컴포넌트 수정
<br />

## :: 구현 사항 설명
1. selected 페이지 공통 컴포넌트 생성
- title의 값과 button값, 그리고 width값만 다른 form이 두개 필요하기 때문에 SelectedForm이라는 공통 배경 컴포넌트 생성, props로 title, width값, children으로 내용을 받음.

2. selected 페이지 userInfo 레이아웃 구현
- 상수 데이터 INPUT_LIST를 사용해 input 구현 , id값에 exam이 포함된 input들은 추후 받아온 데이터를 value값으로 넣어주고 변하지 않을 값이기 때문에 disabled로 설정.
- id에 phone이 포함된 input들은 인증 절차를 거칠 버튼이 필요하기 때문에 추가로 버튼을 넣어줌
- phone & email은 유효성 검사를 진행하기 위해 p태그를 밑에 추가로 넣어줌 (추후 유효성 검사 진행 예정)

3. selected 페이지 좌석선택 레이아웃 구현
- grid를 사용해 칠판, 창문, 문의 자리를 먼저 잡아주고 (grid-template-areas활용) seats부분에 받아오는 정보를 map매서드를 사용해 (array -> array -> object로 접근해야하기 때문에 map함수를 두번 사용함) 각각의 그리드에 넣어줌.

4. Button 컴포넌트 수정
- 다양한 사이즈와 color에 대한 props와 내용을 받기 위해 children, size, color props를 추가로 생성
- sizeList를 object로 설정하여 원하는 값을 넣어주면 그에 맞는 사이즈의 버튼을 생성할 수 있돌록 함!
<br />

## :: 성장 포인트 
- 공통 컴포넌트는 props로 값들을 꼭 넘겨주어야해서 다양한 값들을 모두 넘겨주어야 한다.
- grid의 사용법을 익힘 -> 블로그 작성 완료!
<br />

