### PR TITLE
[41기 이진경] Feature: 시험 리스트 페이지 기능 구현 완료

### DIFF
--- a/public/data/data.json
+++ b/public/data/data.json
@@ -1,4 +1,37 @@
 [
-  { "id": 1, "title": "123" },
-  { "id": 2, "title": "345" }
+  {
+    "testName": "캘픽",
+    "testInfo": [
+      {
+        "testDate": "2023년 3월 25일",
+        "receiptDate": "2023년 2월 25일",
+        "announceDate": "2023년 4월 25일",
+        "receptionStatus": "접수하기"
+      },
+      {
+        "testDate": "2023년 3월 26일",
+        "receiptDate": "2023년 2월 26일",
+        "announceDate": "2023년 4월 26일",
+        "receptionStatus": "접수하기"
+      },
+      {
+        "testDate": "2023년 3월 27일",
+        "receiptDate": "2023년 2월 27일",
+        "announceDate": "2023년 4월 27일",
+        "receptionStatus": "접수예정"
+      },
+      {
+        "testDate": "2023년 3월 28일",
+        "receiptDate": "2023년 2월 28일",
+        "announceDate": "2023년 4월 28일",
+        "receptionStatus": "접수예정"
+      },
+      {
+        "testDate": "2023년 3월 29일",
+        "receiptDate": "2023년 2월 29일",
+        "announceDate": "2023년 4월 29일",
+        "receptionStatus": "접수예정"
+      }
+    ]
+  }
 ]

--- a/src/Router.js
+++ b/src/Router.js
@@ -6,6 +6,7 @@ import Selected from './pages/Selected/Selected';
 import Mypage from './pages/Mypage/Mypage';
 import Footer from './components/Footer/Footer';
 import Redirect from './pages/Login/SocialLogin/Redirect';
+import ExamList from './pages/ExamList/ExamList';
 
 const Router = () => {
   return (
@@ -16,6 +17,7 @@ const Router = () => {
         <Route path="/selected" element={<Selected />} />
         <Route path="/mypage" element={<Mypage />} />
         <Route path="/redirect" element={<Redirect />} />
+        <Route path="/examlist" element={<ExamList />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/pages/ExamInfo/ExamInfo.js
+++ b/src/pages/ExamInfo/ExamInfo.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import InfoTable from './Components/InfoTable/InfoTable';
+import MapInfo from './Components/MapInfo/MapInfo';
+import SelectedInfo from './Components/SelectedInfo/SelectedInfo';
+import * as S from './ExamInfo.styles';
+
+export default function ExamInfo() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const examNameParams = searchParams.get('examName');
+  const testDateParams = searchParams.get('testDate');
+
+  const [checkRdoId, setCheckRdoId] = useState('');
+  const [examData, setExamData] = useState([]);
+  const [districts, setDistricts] = useState([]);
+  const [testSites, setTestSites] = useState([]);
+  const [selectedData, setSelectedData] = useState({
+    examName: examNameParams || '캘픽',
+    testDate: testDateParams || '시험일을 선택해주세요',
+    districts: '지역구를 선택해주세요',
+    name: '시험 고사장을 선택해주세요',
+    address: '고사장 선택시 주소가 보여집니다',
+  });
+
+  console.log(examNameParams);
+
+  useEffect(() => {
+    fetch(`http://10.58.52.136:3000/tests?testName=${selectedData.examName}`)
+      .then(res => res.json())
+      .then(res => {
+        setExamData(res);
+      });
+  }, []);
+
+  const districtsData = date => {
+    fetch(
+      `http://10.58.52.136:3000/tests?testName=${selectedData.examName}&testDate=${date}&provinceName=서울`
+    )
+      .then(res => res.json())
+      .then(res => setDistricts(res[0].districts));
+  };
+
+  const clickHandler = districtName => {
+    fetch(
+      `http://10.58.52.136:3000/tests?testName=${selectedData.examName}&testDate=${selectedData.testDate}&provinceName=서울&districtName=${districtName}`
+    )
+      .then(res => res.json())
+      .then(res => {
+        setExamData(res);
+        setTestSites(res[0].testSites);
+      });
+  };
+
+  return (
+    <S.examInfoContainer className="inner">
+      <InfoTable
+        examData={examData}
+        districts={districts}
+        testSites={testSites}
+        checkRdoid={checkRdoId}
+        selectedData={selectedData}
+        setSelectedData={setSelectedData}
+        setCheckRdoId={setCheckRdoId}
+        districtsData={districtsData}
+        clickHandler={clickHandler}
+      />
+      <SelectedInfo selectedData={selectedData} />
+      <MapInfo selectedData={selectedData} testSites={testSites} />
+    </S.examInfoContainer>
+  );
+}

--- a/src/pages/ExamList/Components/ExamPlan/ExamPlan.jsx
+++ b/src/pages/ExamList/Components/ExamPlan/ExamPlan.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+
+import ExamPlanList from '../ExamPlanList/ExamPlanList';
+import * as S from './ExamPlan.styles';
+
+export default function ExamPlan() {
+  const [dateList, setDateList] = useState([]);
+  const [examName, setExamName] = useState('캘픽');
+
+  useEffect(() => {
+    fetch(`http://10.58.52.136:3000/tests?testName=${examName}`)
+      .then(response => response.json())
+      .then(data => setDateList(data));
+  }, [examName]);
+
+  const changeHandler = e => {
+    setExamName(e.target.value);
+  };
+
+  return (
+    <>
+      <S.ExamTitleContainer>
+        {EXAM_LIST.map(title => {
+          return (
+            <S.ExamTitle>
+              <S.ExamInput
+                type="radio"
+                name="examtitle"
+                id={title.name}
+                value={title.title}
+                onChange={changeHandler}
+              ></S.ExamInput>
+              <S.ExamLabel htmlFor={title.name}>{title.title}</S.ExamLabel>
+            </S.ExamTitle>
+          );
+        })}
+      </S.ExamTitleContainer>
+      <S.TableTitle>시험 접수</S.TableTitle>
+      <S.TableContainer>
+        <S.ListItemContainer>
+          {TITLE_LIST.map(list => {
+            return <S.ListItemTitle>{list.title}</S.ListItemTitle>;
+          })}
+        </S.ListItemContainer>
+        {dateList.map(info => {
+          return (
+            <>
+              <S.ListItemContainer>
+                <ExamPlanList info={info} examName={examName}></ExamPlanList>
+              </S.ListItemContainer>
+            </>
+          );
+        })}
+      </S.TableContainer>
+    </>
+  );
+}
+
+const TITLE_LIST = [
+  {
+    id: 1,
+    title: '시험일',
+  },
+  {
+    id: 2,
+    title: '접수기간',
+  },
+  {
+    id: 3,
+    title: '성적발표일',
+  },
+  {
+    id: 4,
+    title: '시험접수',
+  },
+];
+
+const EXAM_LIST = [
+  {
+    id: 1,
+    title: '캘픽',
+    name: '캘픽',
+  },
+  {
+    id: 2,
+    title: '캘픽스피킹',
+    name: '캘픽스피킹',
+  },
+  {
+    id: 3,
+    title: '오캘픽',
+    name: '오캘픽',
+  },
+  {
+    id: 4,
+    title: '캘픽스',
+    name: '캘픽스',
+  },
+];

--- a/src/pages/ExamList/Components/ExamPlan/ExamPlan.styles.js
+++ b/src/pages/ExamList/Components/ExamPlan/ExamPlan.styles.js
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+export const ExamTitleContainer = styled.div`
+  margin-top: 20px;
+`;
+
+export const ExamTitle = styled.span`
+  border: 1px solid ${({ theme }) => theme.colors.control};
+  padding: 15px 22px 15px 15px;
+  margin-right: 10px;
+  /* border-radius: 10px; */
+  background-color: ${({ theme }) => theme.colors.control};
+  font-size: ${({ theme }) => theme.fontSize.title3};
+  color: ${({ theme }) => theme.colors.basic};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const ExamInput = styled.input`
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+
+  &:checked + label {
+    color: ${({ theme }) => theme.colors.primary};
+    font-weight: ${({ theme }) => theme.fontWeight.bold};
+  }
+`;
+
+export const ExamLabel = styled.label``;
+
+export const TableTitle = styled.h1`
+  /* border: 1px solid red; */
+  margin: 80px 0 50px 0;
+  padding: 30px 0;
+  text-align: center;
+  font-size: ${({ theme }) => theme.fontSize.title1};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  color: ${({ theme }) => theme.colors.basic};
+`;
+
+export const TableContainer = styled.ul`
+  ${({ theme }) => theme.variables.flex}
+  flex-wrap: wrap;
+  border: 1px solid ${({ theme }) => theme.colors.primary};
+`;
+
+export const ListItemContainer = styled.li`
+  ${({ theme }) => theme.variables.flex}
+  border-bottom: 1px solid  ${({ theme }) => theme.colors.control};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.basic};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary};
+    font-weight: ${({ theme }) => theme.fontWeight.bold};
+  }
+`;
+
+export const ListItemTitle = styled.div`
+  border-bottom: 1px solid ${({ theme }) => theme.colors.primary};
+  width: 281px;
+  padding: 20px 0;
+  font-size: ${({ theme }) => theme.fontSize.title2};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  color: ${({ theme }) => theme.colors.primary};
+`;

--- a/src/pages/ExamList/Components/ExamPlanList/ExamPlanList.jsx
+++ b/src/pages/ExamList/Components/ExamPlanList/ExamPlanList.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Button from '../../../../components/Button';
+import * as S from './ExamPlanList.styles';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+export default function ExamPlanList({ info, examName }) {
+  const [searchParams, SetSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const clickHandler = () => {
+    searchParams.set('examName', examName);
+    searchParams.set('testDate', info.testDate);
+    SetSearchParams(searchParams);
+    navigate('/examInfo');
+  };
+
+  const changeDate = date => {
+    const testDate = date.split('-');
+    return testDate[0] + '년 ' + testDate[1] + '월 ' + testDate[2] + '일';
+  };
+
+  return (
+    <>
+      <S.ListItem>{changeDate(info.registerDate)}</S.ListItem>
+      <S.ListItem>{changeDate(info.registerDate)}</S.ListItem>
+      <S.ListItem>{changeDate(info.releaseDate)}</S.ListItem>
+      <S.ListItem>
+        <Button size="medium" color="primary" onClick={clickHandler}>
+          접수하기
+        </Button>
+      </S.ListItem>
+    </>
+  );
+}

--- a/src/pages/ExamList/Components/ExamPlanList/ExamPlanList.styles.js
+++ b/src/pages/ExamList/Components/ExamPlanList/ExamPlanList.styles.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const ListItem = styled.div`
+  width: 281px;
+  padding: 25px 0 10px 0;
+  font-size: ${({ theme }) => theme.fontSize.title3};
+
+  &:last-child {
+    padding: 10px 0;
+  }
+`;

--- a/src/pages/ExamList/ExamList.js
+++ b/src/pages/ExamList/ExamList.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ExamPlan from './Components/ExamPlan/ExamPlan';
+import * as S from './ExamList.styles';
+
+export default function ExamList() {
+  return (
+    <S.ExamListContainer className="inner">
+      <ExamPlan />
+      <S.Logo src="images/logo.png" />
+    </S.ExamListContainer>
+  );
+}

--- a/src/pages/ExamList/ExamList.styles.js
+++ b/src/pages/ExamList/ExamList.styles.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const ExamListContainer = styled.div`
+  position: relative;
+`;
+
+export const Logo = styled.img`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: -250px;
+  width: 150px;
+  height: 60px;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 시험 리스트 페이지 레이아웃 구현 하기
- 시험명 클릭시 해당 시험일자 데이터 보여주는 조건부 렌더링 기능 구현하기
- 접수하기 버튼 클릭시 시험명과 선택 날짜 시험접수페이지로 전송기능 구현하기

<br />

## :: 구현 사항 설명
1. input 사용해 체크된 input의 데이터에 따라 일치하는 일자데이터 조건부 렌더링으로 보여주기
- 체크된 input의 데이터를 백엔드에 GET 요청해 렌더링 해줌

2. 유저가 접수하기 버튼 눌러서 시험접수 페이지로 이동하면 선택한 시험명 , 날짜 같이 이동시켜서 고정값으로 적용시키기 
- searchParams 사용해서 선택된 데이터들 시험 접수 페이지로 전송 완료


<br />

## :: 성장 포인트 


<br />

## :: 기타 질문 및 특이 사항

